### PR TITLE
Fix "init_detector" error and update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ Followed ComfyUI's manual installation steps and do the following:
   - Navigate to your `/ComfyUI/custom_nodes/Comfyui-MusePose` folder and run
   ```shell
    pip install -r requirements.txt
-
-   pip install --no-cache-dir -U openmim 
-   mim install mmengine 
-   mim install "mmcv>=2.0.1" 
-   mim install "mmdet>=3.1.0" 
-   mim install "mmpose>=1.1.0" 
   ```
   - Start ComfyUI
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,12 @@ scikit-learn==1.3.2
 transformers==4.33.1
 moviepy==1.0.3
 urllib3==1.26.9
-torch
-torchdiffeq
-torchmetrics
-torchsde
-torchvision
+--extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.1.2
+torchvision==0.16.2
+torchdiffeq==0.2.3
+torchmetrics==1.2.1
+torchsde==0.2.5
 accelerate==0.29.3
 av==11.0.0
 clip @ https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip#sha256=b5842c25da441d6c581b53a5c60e0c2127ebafe0f746f8e15561a006c6c3be6a
@@ -21,4 +22,10 @@ decord==0.6.0; sys_platform != 'darwin' and platform_machine != 'arm64'
 eva-decord==0.6.1; sys_platform == 'darwin' and platform_machine == 'arm64'
 diffusers>=0.24.0,<=0.27.2
 open-clip-torch==2.20.0
-xformers
+xformers==0.0.23.post1
+wheel==0.43.0
+-f https://download.openmmlab.com/mmcv/dist/cu121/torch2.1/index.html
+mmcv==2.1.0
+mmengine==0.10.4
+mmdet==3.3.0
+mmpose==1.3.1


### PR DESCRIPTION
Related Issues:
- #2 

`pip install torch` will install latest `torch` version and `mmdet` is not compatible with latest `torch` version and it caused this error.  

Changed:

1. Downgrade `torch` versions to compatible with `mmcv`s
2. Update `xformers` to latest compatible version
3. Include `mmcv` series in requirements and add `wheel`  ( without wheel, there's a bug that installing mmcv takes forever )
4. Update README to reflect changes.

Tested with [musepose-workflow-demo.json](https://github.com/TMElyralab/Comfyui-MusePose/blob/main/musepose-workflow-demo.json) and confirmed that it works fine.
