### PR TITLE
hotfix: ImportError: cannot import name 'cached_download' from 'huggingface_hub'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ eva-decord==0.6.1; sys_platform == 'darwin' and platform_machine == 'arm64'
 diffusers>=0.24.0,<=0.27.2
 open-clip-torch==2.20.0
 xformers
+huggingface_hub<0.26.0


### PR DESCRIPTION
Prevent `huggingface_hub` from upgrading to the latest version, which is incompatible. Keep below version 0.26.0.

Issue description: https://github.com/huggingface/huggingface-inference-toolkit/issues/92

HotFix description: https://github.com/huggingface/huggingface-inference-toolkit/issues/92#issuecomment-2426348201